### PR TITLE
Switch to saloonphp/saloon from sammyjo20/saloon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "sammyjo20/saloon": "^2.0"
+        "saloonphp/saloon": "^2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.4",


### PR DESCRIPTION
It appears that the [Packagist name of the Saloon package has changed ](https://packagist.org/packages/sammyjo20/saloon). This pull request simply updates the package in composer.json to the new name, preventing deprecation warnings for users of the package.

Thanks for a great & helpful project!